### PR TITLE
Route53のホストゾーンの作成をglobal配下へ移行

### DIFF
--- a/infra/global/modules/route53/main.tf
+++ b/infra/global/modules/route53/main.tf
@@ -1,0 +1,5 @@
+# ホストゾーンだけは破壊されたくないのでGlobalで作成(破壊するとネームサーバーが変更になってしまう)
+resource "aws_route53_zone" "main" {
+  name = var.root_domain
+  tags = var.tags
+}

--- a/infra/global/modules/route53/variables.tf
+++ b/infra/global/modules/route53/variables.tf
@@ -1,0 +1,8 @@
+variable "root_domain" {
+  type        = string
+  description = "Domain For ALB"
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -61,6 +61,7 @@ module "dns" {
 
   prefix                        = local.default_prefix
   root_domain                   = var.root_domain
+  host_zone_id                  = var.host_zone_id
   alb_dns_name                  = module.web_app.alb_dns_name
   alb_zone_id                   = module.web_app.alb_zone_id
   acm_main_domain_valid_options = module.cert.acm_main_domain_valid_options

--- a/infra/staging/modules/dns/main.tf
+++ b/infra/staging/modules/dns/main.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "main" {
 # NOTE: ドメイン取得元でネームサーバーを↑のホストゾーンに向ける必要がある
 # ドメインをRoute53に移管するなどの対応を検討
 resource "aws_route53_record" "alb" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = var.host_zone_id
   name    = var.root_domain
   type    = "A"
 
@@ -31,7 +31,7 @@ resource "aws_route53_record" "cert_validation_main" {
   type            = each.value.type
   ttl             = "300"
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = var.host_zone_id
 }
 
 resource "aws_route53_record" "cert_validation_sub" {
@@ -49,5 +49,5 @@ resource "aws_route53_record" "cert_validation_sub" {
   type            = each.value.type
   ttl             = "300"
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = var.host_zone_id
 }

--- a/infra/staging/modules/dns/variables.tf
+++ b/infra/staging/modules/dns/variables.tf
@@ -6,6 +6,11 @@ variable "root_domain" {
   type        = string
   description = "RootDomain"
 }
+variable "host_zone_id" {
+  type        = string
+  description = "global配下で作成したRoute53のホストゾーンID"
+  sensitive   = true
+}
 variable "alb_dns_name" {
   type        = string
   description = "DNS Name For ALB"

--- a/infra/staging/terraform.auto.tfvars
+++ b/infra/staging/terraform.auto.tfvars
@@ -46,3 +46,4 @@ vpc_endpoint = {
   ]
 }
 root_domain = "pr-bun.com"
+# TODO: hosto_zone_id = "hoge" が必要(globalでroute53のホストゾーンを作成してここにidを用意しておく)

--- a/infra/staging/variables.tf
+++ b/infra/staging/variables.tf
@@ -31,6 +31,11 @@ variable "root_domain" {
   type        = string
   description = "Domain For ALB"
 }
+variable "host_zone_id" {
+  type        = string
+  description = "global配下で作成したRoute53のホストゾーンID"
+  sensitive   = true
+}
 variable "tags" {
   type = map(string)
   default = {


### PR DESCRIPTION
移行理由

- ホストゾーンが消されると ドメイン取得元で指定するns serverの値をまた変更する必要がある
- stagingリソースは頻繁に削除するため、↑に向かない
- globalでホストゾーンを作成することで上記問題を解決(Aレコードなどは都度作成でOK)